### PR TITLE
Bypass amavisd. Refs #3411

### DIFF
--- a/root/etc/e-smith/templates/etc/postfix/master.cf/30amavisd-before-queue
+++ b/root/etc/e-smith/templates/etc/postfix/master.cf/30amavisd-before-queue
@@ -38,9 +38,10 @@
 
     $OUT .= '127.0.0.1:10025 inet n  -       n       -        -      smtpd' . $smtpdAfterFilterOptions;
 
-    # Filter for submission listeners:
-    if(defined @submission_smtpd_options) {
-	push @submission_smtpd_options, 'smtpd_proxy_filter=127.0.0.1:10587';
+    # submission listeners talk directly to the backend instance (queue)
+    # if disclaimers are not defined (See #3411):
+    if(@submission_smtpd_options) {
+        push @submission_smtpd_options, 'smtpd_proxy_filter=127.0.0.1:' . ($hasDisclaimers ? 10587 : 10025);
     }
 
     return $OUT;


### PR DESCRIPTION
If no disclaimer is defined amavisd is completely bypassed on
submission.

See NethServer/nethserver-mail-common#8

---

http://dev.nethserver.org/issues/3411
