### PR TITLE
Reset syslog_name to default value

### DIFF
--- a/root/etc/e-smith/templates/etc/postfix/master.cf/30amavisd-before-queue
+++ b/root/etc/e-smith/templates/etc/postfix/master.cf/30amavisd-before-queue
@@ -30,7 +30,6 @@
     -o smtpd_data_restrictions=
     -o mynetworks=127.0.0.0/8
     -o receive_override_options=no_unknown_recipient_checks
-    -o syslog_name=queue
 );
 
     # Filter for public listener:


### PR DESCRIPTION
See also http://dev.nethserver.org/issues/2784, NethServer/nethserver-mail-common#9
